### PR TITLE
schedule: render 'misc' as markdown

### DIFF
--- a/shortcodes/schedule.html
+++ b/shortcodes/schedule.html
@@ -60,7 +60,7 @@
                         <p><a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default .Title -}}</strong></a></p>
                     {{ end }}
                 {{ else if $notes }}
-                    <p>{{- $notes -}}</p>
+                    <p>{{- $notes | markdownify -}}</p>
                 {{ end }}
             {{ end }}
             </td>


### PR DESCRIPTION
render comments in "misc" properly as markdown ... 