### PR TITLE
Zeilenumbruch in Woche-Spalte. Fixes #3.

### DIFF
--- a/shortcodes/schedule.html
+++ b/shortcodes/schedule.html
@@ -23,7 +23,8 @@
         {{ $misc := index $w "misc" }}
         <tr>
             <td>
-                {{ printf "%d" (add $i 1) }} <br>
+                {{ printf "%d" (add $i 1) }}
+                <br>
                 {{ printf "(%s)" $week }}
             </td>
             <td>

--- a/shortcodes/schedule.html
+++ b/shortcodes/schedule.html
@@ -22,7 +22,10 @@
         {{ $assignment := index $w "assignment" }}
         {{ $misc := index $w "misc" }}
         <tr>
-            <td>{{ printf "Woche %d (%s)" (add $i 1) $week }}</td>
+            <td>
+                {{ printf "%d" (add $i 1) }} <br>
+                {{ printf "(%s)" $week }}
+            </td>
             <td>
             <ul>
             {{ range $n, $l := $lecture }}


### PR DESCRIPTION
Text "Woche" weglassen und Zeilenumbruch zwischen Wochenzahl und (KWxx) hinzufügen, um Spaltenbreite zu reduzieren.
Fixes issue #3 