### PR TITLE
Leerraum in Tabellenzelle reduzieren. Fixes issue #2.

### DIFF
--- a/partials/custom-header.html
+++ b/partials/custom-header.html
@@ -127,8 +127,8 @@ figcaption h4 {
 
 /* Adjust margin and padding around list-elemeents within table cells */
 td ul, td ol {
-    margin: 0.5rem 0;
-    padding: 0 0.5rem;
+    margin: 0;
+    padding: 0 0.5rem 0 1rem;
 }
 
 </style>

--- a/partials/custom-header.html
+++ b/partials/custom-header.html
@@ -125,4 +125,10 @@ figcaption h4 {
     border:1px solid black;
 }
 
+/* Adjust margin and padding around list-elemeents within table cells */
+td ul, td ol {
+    margin: 0.5rem 0;
+    padding: 0 0.5rem;
+}
+
 </style>

--- a/partials/custom-header.html
+++ b/partials/custom-header.html
@@ -127,8 +127,8 @@ figcaption h4 {
 
 /* Adjust margin and padding around list-elemeents within table cells */
 td ul, td ol {
-    margin: 0;
-    padding: 0 0.5rem 0 1rem;
+    margin: 0 0 1rem 0.5rem;
+    padding: 0 0 0 0.5rem;
 }
 
 </style>


### PR DESCRIPTION
Margin und Padding um Listen-Elemente in Tabellenzellen anpassen,
um Leerraum zu reduzierem und Lesbarkeit zu erhöhen.
Fixes issue #2 .