### PR TITLE
Schedule: "misc_ assignment" analog zu "misc_lecture" neu

### DIFF
--- a/shortcodes/schedule.html
+++ b/shortcodes/schedule.html
@@ -22,6 +22,7 @@
         {{ $assignment := index $w "assignment" }}
         {{ $misc_column := index $w "misc_column" }}
         {{ $misc_lecture := index $w "misc_lecture" }}
+        {{ $misc_assignment := index $w "misc_assignment" }}
         <tr>
             <td>
                 {{ printf "%d" (add $i 1) }}
@@ -64,6 +65,21 @@
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
                     {{ if $due }}<br>(Abgabe: {{- $due -}})<br>{{ end }}
                 {{ end }}
+            {{ end }}
+            {{ if $misc_assignment }}
+            <p>
+            {{ range $misc_assignment }}
+                {{ $page := index . "page" }}
+                {{ $notes := index . "notes" }}
+                {{ if $page }}
+                    {{ with $.Site.GetPage $page }}
+                        <a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default .Title -}}</strong></a><br>
+                    {{ end }}
+                {{ else if $notes }}
+                    {{- $notes | markdownify -}}<br>
+                {{ end }}
+            {{ end }}
+            </p>
             {{ end }}
             </td>
             {{ if $if_misc_column }}


### PR DESCRIPTION
@cyildiz Nach einer Diskussion mit BC heute habe ich noch ein `misc_assignment` neu hinzugefügt mit den selben Variablen und Möglichkeiten wie `misc_lecture` und `misc_column`.

Damit kann man nun frei in allen drei Spalten (Vorlesung, Übung, Verschiedenes) Kommentare einsetzen, wobei die Spalte "Verschiedenes" nur dann angezeigt wird, wenn in mind. einer Woche auch `misc_column` genutzt wurde.

fixes #13 