### PR TITLE
Attachments nur anzeigen, falls sie existieren.

### DIFF
--- a/partials/attachments.html
+++ b/partials/attachments.html
@@ -10,7 +10,7 @@
     {{ $level = . }}
 {{ end }}
 
-{{ id $attachments }}
+{{ if $attachments }}
 <div class="attachments">
     <h{{- $level -}}>{{- $header -}}</h{{- $level -}}>
 

--- a/partials/attachments.html
+++ b/partials/attachments.html
@@ -10,6 +10,7 @@
     {{ $level = . }}
 {{ end }}
 
+{{ id $attachments }}
 <div class="attachments">
     <h{{- $level -}}>{{- $header -}}</h{{- $level -}}>
 
@@ -31,3 +32,4 @@
     {{ end }}
     </ul>
 </div>
+{{ end }}


### PR DESCRIPTION
Folien Überschrift und section nur anzeigen, falls Datein im Folder files/ existieren.
Fixes issue #21 