### PR TITLE
remove 'markdownify' for custom rendering of schedule notes

### DIFF
--- a/shortcodes/schedule.html
+++ b/shortcodes/schedule.html
@@ -58,7 +58,7 @@
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default $title -}}</strong></a><br>
                     {{ end }}
                 {{ else if $notes }}
-                    {{- $notes | markdownify -}}<br>
+                    {{- $notes -}}<br>
                 {{ end }}
             {{ end }}
             </td><td>
@@ -86,7 +86,7 @@
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default $title -}}</strong></a><br>
                     {{ end }}
                 {{ else if $notes }}
-                    {{- $notes | markdownify -}}<br>
+                    {{- $notes -}}<br>
                 {{ end }}
             {{ end }}
             </td>
@@ -101,7 +101,7 @@
                         <a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default $title -}}</strong></a><br>
                     {{ end }}
                 {{ else if $notes }}
-                    {{- $notes | markdownify -}}<br>
+                    {{- $notes -}}<br>
                 {{ end }}
             {{ end }}
             </td>


### PR DESCRIPTION
this could have been a way to allow for custom formatting of notes in our schedule. however, this was not working in all circumstances. so removing this and return to plain text notes ...

fixes #18